### PR TITLE
Drop iOS 9 support

### DIFF
--- a/ios/fatigue.xcodeproj/project.pbxproj
+++ b/ios/fatigue.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = SDRF2SCZQU;
 				INFOPLIST_FILE = fatigue/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lelandjansen.fatigue;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -531,7 +531,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = SDRF2SCZQU;
 				INFOPLIST_FILE = fatigue/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lelandjansen.fatigue;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/fatigue/Notifications.swift
+++ b/ios/fatigue/Notifications.swift
@@ -5,46 +5,31 @@ enum NotificationKeys: String {
 }
 
 func registerLocalNotifications() {
-    if #available(iOS 10.0, *) {
-        let notificationCenter = UNUserNotificationCenter.current()
-        notificationCenter.requestAuthorization(options: [.alert, .sound]) { (granted, error) in
-            
-        }
-    }
-    else {
-        // Fallback on earlier versions
+    let notificationCenter = UNUserNotificationCenter.current()
+    notificationCenter.requestAuthorization(options: [.alert, .sound]) { (granted, error) in
+        
     }
 }
 
 func disableLocalNotifications() {
     UserDefaults.standard.reminderEnabled = false
-    if #available(iOS 10.0, *) {
-        let notificationCenter = UNUserNotificationCenter.current()
-        notificationCenter.removeAllPendingNotificationRequests()
-    }
-    else {
-        // Fallback on earlier versions
-    }
+    let notificationCenter = UNUserNotificationCenter.current()
+    notificationCenter.removeAllPendingNotificationRequests()
 }
 
 func scheduleLocalNotifications(atTime time: DateComponents) {
     UserDefaults.standard.reminderEnabled = true
     UserDefaults.standard.reminderTime = time
     
-    if #available(iOS 10.0, *) {
-        let center = UNUserNotificationCenter.current()
-        center.removeAllPendingNotificationRequests()
-        
-        let content = UNMutableNotificationContent()
-        content.title = "Reminder"
-        content.body = "Please complete today's self-assessment."
-        content.sound = UNNotificationSound.default()
-        
-        let trigger = UNCalendarNotificationTrigger(dateMatching: time, repeats: true)
-        let request = UNNotificationRequest(identifier: NotificationKeys.dailyReminder.rawValue, content: content, trigger: trigger)
-        center.add(request, withCompletionHandler: nil)
-    }
-    else {
-        // Fallback on earlier versions
-    }
+    let notificationCenter = UNUserNotificationCenter.current()
+    notificationCenter.removeAllPendingNotificationRequests()
+    
+    let content = UNMutableNotificationContent()
+    content.title = "Reminder"
+    content.body = "Please complete today's self-assessment."
+    content.sound = UNNotificationSound.default()
+    
+    let trigger = UNCalendarNotificationTrigger(dateMatching: time, repeats: true)
+    let request = UNNotificationRequest(identifier: NotificationKeys.dailyReminder.rawValue, content: content, trigger: trigger)
+    notificationCenter.add(request, withCompletionHandler: nil)
 }

--- a/ios/fatigue/SupervisorSettingController.swift
+++ b/ios/fatigue/SupervisorSettingController.swift
@@ -70,9 +70,7 @@ class SupervisorSettingController: UITableViewController, SettingDelegate, UITex
         textField.autocapitalizationType = .words
         textField.clearButtonMode = .whileEditing
         textField.returnKeyType = .done
-        if #available(iOS 10.0, *) {
-            textField.textContentType = .familyName
-        }
+        textField.textContentType = .familyName
         textField.placeholder = "Supervisor's name"
         textField.text = UserDefaults.standard.supervisorName
         return textField
@@ -87,9 +85,7 @@ class SupervisorSettingController: UITableViewController, SettingDelegate, UITex
         textField.clearButtonMode = .whileEditing
         textField.returnKeyType = .done
         textField.keyboardType = .emailAddress
-        if #available(iOS 10.0, *) {
-            textField.textContentType = .emailAddress
-        }
+        textField.textContentType = .emailAddress
         textField.placeholder = "Email"
         textField.text = UserDefaults.standard.supervisorEmail
         return textField
@@ -103,9 +99,7 @@ class SupervisorSettingController: UITableViewController, SettingDelegate, UITex
         textField.clearButtonMode = .whileEditing
         textField.keyboardType = .phonePad
         textField.placeholder = "Mobile"
-        if #available(iOS 10.0, *) {
-            textField.textContentType = .telephoneNumber
-        }
+        textField.textContentType = .telephoneNumber
         textField.text = UserDefaults.standard.supervisorPhone
         return textField
     }()


### PR DESCRIPTION
Drop support for iOS 9. iOS 11 is coming out in the fall making iOS 9 two years old. This simplifies the code logic (especially for notification handling) and means the app doesn't need to be tested on an additional version (speeds up testing before release).